### PR TITLE
Fixes for wildcard/dual certificates and non-dynamic domains, plus cleanup hook script.

### DIFF
--- a/.dedynauth
+++ b/.dedynauth
@@ -3,4 +3,3 @@ DEDYN_TOKEN=d41d8cd98f00b204e9800998ecf8427e
 
 # Set your dedyn.io domain name here:
 DEDYN_NAME=example.dedyn.io
-

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ was correctly published.
          --text \
          --preferred-challenges dns \
          --manual-auth-hook ./hook.sh \
+         --manual-cleanup-hook ./hook.sh \
          -d "YOURDOMAINNAME.dedyn.io" \
          certonly
 

--- a/hook.sh
+++ b/hook.sh
@@ -4,37 +4,36 @@
 # Please see the .dedynauth file for authentication information.
 
 (
-if [ ! -f .dedynauth ]; then
-    DEDYNAUTH=`pwd`/.dedynauth
+
+DEDYNAUTH=$(pwd)/.dedynauth
+
+if [ ! -f "$DEDYNAUTH" ]; then
     >&2 echo "File $DEDYNAUTH not found. Please place .dedynauth file in appropriate location."
     exit 1
 fi
 
-source .dedynauth
+source "$DEDYNAUTH"
 
-if [ -z "$DEDYN_TOKEN" ] ; then
-    DEDYNAUTH=`pwd`./dedynauth
+if [ -z "$DEDYN_TOKEN" ]; then
     >&2 echo "Variable \$DEDYN_TOKEN not found. Please set DEDYN_TOKEN=(your dedyn.io token) to your dedyn.io access token in $DEDYNAUTH, e.g."
-    >&2 echo 
+    >&2 echo ""
     >&2 echo "DEDYN_TOKEN=d41d8cd98f00b204e9800998ecf8427e"
     exit 2
 fi
 
-if [ -z "$DEDYN_NAME" ] ; then
-    DEDYNAUTH=`pwd`./dedynauth
+if [ -z "$DEDYN_NAME" ]; then
     >&2 echo "Variable \$DEDYN_NAME not found. Please set DEDYN_NAME=(your dedyn.io name) to your dedyn.io name in $DEDYNAUTH, e.g."
-    >&2 echo
+    >&2 echo ""
     >&2 echo "DEDYN_NAME=foobar.dedyn.io"
     exit 3
 fi
 
-if [ -z "$CERTBOT_DOMAIN" ] ; then
-    DEDYNAUTH=`pwd`./dedynauth
+if [ -z "$CERTBOT_DOMAIN" ]; then
     >&2 echo "It appears that you are not running this script through certbot (\$CERTBOT_DOMAIN is unset). Please call with: certbot --manual-auth-hook=$0"
     exit 4
 fi
 
-if [[ ! $(type -P curl) ]] ; then
+if [ ! "$(type -P curl)" ]; then
     >&2 echo "Please install curl to use certbot with dedyn.io."
     exit 5
 fi
@@ -59,25 +58,21 @@ args=( \
 curl -X PUT "${args[@]}" -f "https://desec.io/api/v1/domains/$DEDYN_NAME/rrsets/"
 
 >&2 echo "Verifying challenge is set correctly. This can take up to 2 minutes."
->&2 echo "Current Time: `date`"
+>&2 echo "Current Time: $(date)"
 
-for i in `seq 1 60`;
-do
-
-	CURRENT=$(host -t TXT "_acme-challenge$infix.$DEDYN_NAME" ns1.desec.io | grep -- "$CERTBOT_VALIDATION")
-	if [ ! -z "$CURRENT" ]; then
-		break
-	fi
-	sleep 2
-
+for ((i = 0; i < 60; i++)); do
+    CURRENT=$(host -t TXT "_acme-challenge$infix.$DEDYN_NAME" ns1.desec.io | grep -- "$CERTBOT_VALIDATION")
+    if [ -n "$CURRENT" ]; then
+	break
+    fi
+    sleep 2
 done
 
 if [ -z "$CURRENT" ]; then
-	>&2 echo "Token could not be published. Please check your dedyn credentials."
-	exit 5
+    >&2 echo "Token could not be published. Please check your dedyn credentials."
+    exit 6
 fi
 
 >&2 echo "Token published. Returning to certbot."
 
 )
-

--- a/hook.sh
+++ b/hook.sh
@@ -38,7 +38,7 @@ if [ ! "$(type -P curl)" ]; then
     exit 5
 fi
 
->&2 echo "Setting challenge to ${CERTBOT_VALIDATION} ..."
+echo "Setting challenge to ${CERTBOT_VALIDATION} ..."
 
 # Figure out subdomain infix by removing zone name and trailing dot
 # foobar.dedyn.io gives "" while a.foobar.dedyn.io gives ".a"
@@ -57,8 +57,8 @@ args=( \
 # set ACME challenge (overwrite if possible, create otherwise)
 curl -X PUT "${args[@]}" -f "https://desec.io/api/v1/domains/$DEDYN_NAME/rrsets/"
 
->&2 echo "Verifying challenge is set correctly. This can take up to 2 minutes."
->&2 echo "Current Time: $(date)"
+echo "Verifying challenge is set correctly. This can take up to 2 minutes."
+echo "Current Time: $(date)"
 
 for ((i = 0; i < 60; i++)); do
     CURRENT=$(host -t TXT "_acme-challenge$infix.$DEDYN_NAME" ns1.desec.io | grep -- "$CERTBOT_VALIDATION")
@@ -73,6 +73,6 @@ if [ -z "$CURRENT" ]; then
     exit 6
 fi
 
->&2 echo "Token published. Returning to certbot."
+echo -e '\e[32mToken published. Returning to certbot.\e[0m'
 
 )


### PR DESCRIPTION
Included patches:

- Spacing and formatting fixups for clarity, and as recommended by `shellcheck`.
- Echo status and success messages to stdout instead of stderr.
- Strips leading `*.`s from the domain name to enable verification of wildcard certificates.
- Reads and republishes existing `_acme-challenge`s along with the current challenge, to enable verification of wildcard certificates with SubjectAlternativeNames (e.g. one certificate for *.foo.bar and foo.bar).
- Reads and respects the domain's `minimum_ttl`. This allows the script to be used on any domain served by deSEC, instead of failing on non-`dedyn.io` domains.
- Adds cleanup functionality when called with `--manual-cleanup-hook`.
- Adds documentation of cleanup script to `README.md`

Closes #7 and #12.