### PR TITLE
fix freebsd grep

### DIFF
--- a/hook.sh
+++ b/hook.sh
@@ -66,7 +66,7 @@ args=( \
 
 # Find minimum_ttl for the domain and use that instead of hardcoding a ttl.
 # This allows use on non-dynamic (dedyn.io) domains.
-minimum_ttl=$(curl "${args[@]}" -X GET "https://desec.io/api/v1/domains/$DEDYN_NAME/" | tr -d '\n' | grep -o '"minimum_ttl"[[:space:]]*:[[:space:]]*[[:digit:]]*' | grep -o '[[:digit:]]*')
+minimum_ttl=$(curl "${args[@]}" -X GET "https://desec.io/api/v1/domains/$DEDYN_NAME/" | tr -d '\n' | grep -o '"minimum_ttl"[[:space:]]*:[[:space:]]*[[:digit:]]*' | grep -o '[[:digit:]]*$')
 
 # Fetch and parse the current rrset for manipulation below.
 acme_records=$(curl "${args[@]}" -X GET "https://desec.io/api/v1/domains/$DEDYN_NAME/rrsets/?subname=_acme-challenge$infix&type=TXT" \


### PR DESCRIPTION
Without this change it could not determine the ttl value on
FreeBSD 11.3-RELEASE-p9
grep (GNU grep) 2.5.1-FreeBSD
no clue why

The first grep worked but the second without binding to line end has no output