### PR TITLE
Allow issuing challenges at the domain apex

### DIFF
--- a/hook.sh
+++ b/hook.sh
@@ -12,7 +12,11 @@ shopt -s extglob
 DEDYNAUTH=$(pwd)/.dedynauth
 
 if [ ! -f "$DEDYNAUTH" ]; then
-    >&2 echo "File $DEDYNAUTH not found. Please place .dedynauth file in appropriate location."
+    DEDYNAUTH=$(dirname $0)/.dedynauth
+fi
+
+if [ ! -f "$DEDYNAUTH" ]; then
+    >&2 echo "File $(pwd)/.dedynauth not found. Please place .dedynauth file in appropriate location."
     exit 1
 fi
 


### PR DESCRIPTION
Allow issuing a challenge when deSEC only hosts the `_acme-challenge` subdomain, rather than the full domain. This allows the rest of the DNS zone to be hosted elsewhere, reducing the potential impact if the server running Certbot were to be compromised.

Additionally, allow the `.dedynauth` file to be stored in the same directory as the hook script, for ease of use when running in a cron job or other automation where the current directory may not be easily accessible.